### PR TITLE
fix: add shebang to upload-arduino-sketch (fix Exec format error)

### DIFF
--- a/arduino-env.nix
+++ b/arduino-env.nix
@@ -59,7 +59,7 @@ let
   uploadArduinoSketch = arduinoEnv: {
     arduinoSketch
     , fqbn
-  }: pkgs.writeScriptBin "upload-arduino-sketch" ''
+  }: pkgs.writeShellScriptBin "upload-arduino-sketch" ''
       ${arduinoEnv}/bin/arduino-cli upload --log --input-dir=${arduinoSketch} --fqbn=${fqbn} "$@"
   '';
 


### PR DESCRIPTION
### Summary

Fixes an issue where `upload-arduino-sketch` fails to execute.


### Cause

The script is currently generated using `writeScriptBin` without a shebang. This produces a plain text file that the kernel cannot execute directly.

### Fix

Replace `writeScriptBin` with `writeShellScriptBin`, which:

- adds a proper shebang automatically
- ensures the script is executable
- avoids runtime execution errors